### PR TITLE
Potential fix for code scanning alert no. 20: XML internal entity expansion

### DIFF
--- a/Season-2/Level-3/code.js
+++ b/Season-2/Level-3/code.js
@@ -47,9 +47,9 @@ app.post("/ufo", (req, res) => {
   } else if (contentType === "application/xml") {
     try {
       const xmlDoc = libxmljs.parseXml(req.body, {
-        replaceEntities: true,
+        replaceEntities: false, // Disable entity expansion
         recover: true,
-        nonet: false,
+        nonet: true, // Prevent loading external entities
       });
 
       console.log("Received XML data from XMLon:", xmlDoc.toString());


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/20](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/20)

To fix the vulnerability, entity expansion must be disabled when parsing untrusted XML. In `libxmljs`, this can be achieved by setting `replaceEntities: false` (or omitting it, as the default is `false`). Additionally, setting `nonet: true` will prevent the parser from fetching external entities over the network, further reducing risk. The fix involves changing the options passed to `libxmljs.parseXml` on lines 49–53 in `Season-2/Level-3/code.js` to ensure that both internal and external entity expansion are disabled. No new imports or methods are required; only the options object needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
