### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/Season-2/Level-3/package.json
+++ b/Season-2/Level-3/package.json
@@ -18,7 +18,8 @@
       "path": "^0.12.7",
       "shell-quote": "^1.8.3",
       "sax": "^1.4.1",
-      "sanitize-filename": "^1.6.3"
+      "sanitize-filename": "^1.6.3",
+      "express-rate-limit": "^8.0.1"
     },
     "devDependencies": {
       "chai": "^4.3.8",


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/15](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/15)

To fix the problem, we should add rate limiting to the `/ufo/upload` route to prevent abuse. The best way to do this in an Express application is to use the `express-rate-limit` middleware. We should import `express-rate-limit`, configure a rate limiter (e.g., allow a reasonable number of requests per time window), and apply it specifically to the `/ufo/upload` route. This ensures that the file system access in this handler is protected against excessive requests, without affecting other routes.

The required changes are:
- Import `express-rate-limit` at the top of the file.
- Define a rate limiter instance with appropriate settings (e.g., max 10 requests per minute).
- Apply the rate limiter as middleware to the `/ufo/upload` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
