### PR TITLE
Potential fix for code scanning alert no. 26: SQL query built from user-controlled sources

### DIFF
--- a/Season-1/Level-4/code.py
+++ b/Season-1/Level-4/code.py
@@ -251,7 +251,16 @@ class DB_CRUD_ops(object):
                     safe_query = re.sub(r"where\s+symbol\s*=\s*'[^']+'", "where symbol = ?", query, flags=re.IGNORECASE)
                     cur.execute(safe_query, (symbol,))
                 else:
-                    cur.execute(query)
+                    # Only allow queries that match a safe SELECT pattern
+                    # For demonstration, only allow SELECT statements with a WHERE clause on symbol
+                    match = re.search(r"select\s+.*\s+from\s+\w+\s+where\s+symbol\s*=\s*'([^']+)'", lowered)
+                    if match:
+                        symbol = match.group(1)
+                        safe_query = re.sub(r"where\s+symbol\s*=\s*'[^']+'", "where symbol = ?", query, flags=re.IGNORECASE)
+                        cur.execute(safe_query, (symbol,))
+                    else:
+                        res += "[ERROR] Only SELECT statements with a WHERE clause on symbol are allowed.\n"
+                        return res
                 db_con.commit()
                 query_outcome = cur.fetchall()
                 for result in query_outcome:


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/26](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/26)

To fix the problem, we must ensure that user input is never directly executed as a SQL query. Instead, we should only allow queries that can be safely parameterized, or we should reject any query that cannot be safely handled. In this context, for queries that do not match the `where symbol = '...'` pattern, we should either reject them or attempt to extract parameters and use parameterized queries. Since the code is intended to only allow single SELECT statements, we can further restrict the allowed queries to those that match a safe pattern (e.g., `SELECT ... FROM ... WHERE ... = ?`). For any query that does not match a safe pattern, we should return an error message and avoid executing it.

The changes should be made in the `exec_user_script` method in `Season-1/Level-4/code.py`, specifically replacing the unsafe execution of `cur.execute(query)` on line 254 with a safe alternative or an error message. No new imports are needed, as `re` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
