### PR TITLE
Potential fix for code scanning alert no. 28: SQL query built from user-controlled sources

### DIFF
--- a/Season-1/Level-4/code.py
+++ b/Season-1/Level-4/code.py
@@ -252,14 +252,14 @@ class DB_CRUD_ops(object):
                     cur.execute(safe_query, (symbol,))
                 else:
                     # Only allow queries that match a safe SELECT pattern
-                    # For demonstration, only allow SELECT statements with a WHERE clause on symbol
-                    match = re.search(r"select\s+.*\s+from\s+\w+\s+where\s+symbol\s*=\s*'([^']+)'", lowered)
+                    # Only allow queries of the form: SELECT ... FROM stocks WHERE symbol = '...'
+                    match = re.match(r"^select\s+\*\s+from\s+stocks\s+where\s+symbol\s*=\s*'([^']+)'$", lowered)
                     if match:
                         symbol = match.group(1)
-                        safe_query = re.sub(r"where\s+symbol\s*=\s*'[^']+'", "where symbol = ?", query, flags=re.IGNORECASE)
+                        safe_query = "SELECT * FROM stocks WHERE symbol = ?"
                         cur.execute(safe_query, (symbol,))
                     else:
-                        res += "[ERROR] Only SELECT statements with a WHERE clause on symbol are allowed.\n"
+                        res += "[ERROR] Only queries of the form: SELECT * FROM stocks WHERE symbol = '<symbol>' are allowed.\n"
                         return res
                 db_con.commit()
                 query_outcome = cur.fetchall()


### PR DESCRIPTION
Potential fix for [https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/28](https://github.com/SravandeepReddy2004/skills-secure-code-game/security/code-scanning/28)

To fix the problem, we should avoid using user-supplied SQL fragments to construct queries. Instead, we should use a fixed query template and only allow the user to supply the value for the `symbol` parameter. Specifically, in the `exec_user_script` method, we should reject any query that does not match the exact pattern we expect (e.g., `SELECT ... FROM stocks WHERE symbol = ?`), and extract only the symbol value from the user input. The query itself should be a fixed string, and the symbol should be passed as a parameter to the `execute` method. This change should be made in the region of lines 255-263, replacing the regex-based query construction with a strict template and parameterization. We may also need to update the error handling to reflect the stricter requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
